### PR TITLE
Add package-requires for external rtm

### DIFF
--- a/lisp/simple-rtm.el
+++ b/lisp/simple-rtm.el
@@ -5,6 +5,7 @@
 ;; Author: Moritz Bunkus <morit@bunkus.org>
 ;; Created: April 3, 2011
 ;; Version: 0.3
+;; Package-Requires: ((rtm "0.1"))
 ;; Keywords: remember the milk productivity todo
 
 ;; This product uses the Remember The Milk API but is not endorsed or


### PR DESCRIPTION
I'm currently working on my own package org-rtm which also uses rtm.el. The melpa maintainer and me decided it would be a good idea to put the rtm.el into a separate package, which you can depend on, too (using the package-requries line).

This might actually fix #10, by the way. I stumbled on that problem, too with rtm.el.

The corresponding pull request to melpa is here, by the way: https://github.com/milkypostman/melpa/pull/3496